### PR TITLE
Updated Missile functionality to 4.21.2

### DIFF
--- a/Source/MissileDemo/Missile.cpp
+++ b/Source/MissileDemo/Missile.cpp
@@ -35,7 +35,7 @@ AMissile::AMissile(const FObjectInitializer& ObjectInitializer) : Super(ObjectIn
 	ProjectileMovement->Velocity = FVector(0, 0, 0);
 
 	// Bind our OnOverlapBegin Event
-	CollisionComp->OnComponentBeginOverlap.AddDynamic(this, &AMissile::OnOverlapBegin);
+	//CollisionComp->OnComponentBeginOverlap.AddDynamic(this, &AMissile::OnOverlapBegin);
 
 	// Set Default Values for Variables
 	hasTargetPosition = false;

--- a/Source/MissileDemo/Missile.cpp
+++ b/Source/MissileDemo/Missile.cpp
@@ -3,6 +3,9 @@
 #include "Missile.h"
 #include "MissileDemo.h"
 #include "MyCharacter.h"
+#include "Components/BoxComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "EngineUtils.h"
 
 // Sets default values
 AMissile::AMissile(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
@@ -16,8 +19,8 @@ AMissile::AMissile(const FObjectInitializer& ObjectInitializer) : Super(ObjectIn
 
 	// Construct Static Mesh Component
 	MissileMesh = ObjectInitializer.CreateDefaultSubobject<UStaticMeshComponent>(this, TEXT("MissileMesh"));
-	const ConstructorHelpers::FObjectFinder<UStaticMesh> MeshObj(TEXT("/Game/Missile/Missile_01_Model"));
-	MissileMesh->SetStaticMesh(MeshObj.Object);
+	//const ConstructorHelpers::FObjectFinder<UStaticMesh> MeshObj(TEXT("/Game/Missile/Missile_01_Model"));
+	//MissileMesh->SetStaticMesh(MeshObj.Object);
 	MissileMesh->SetupAttachment(RootComponent);
 
 	// Construct Projectile Movement Component
@@ -44,7 +47,7 @@ AMissile::AMissile(const FObjectInitializer& ObjectInitializer) : Super(ObjectIn
 	hasFinishedDelay = false;
 	lifetimeCountdown = 15.f;
 	canBeDestroyed = false;
-	PlayerInWorld = NULL;
+	PlayerCharacter = NULL;
 }
 
 #pragma region Setup Target Logic
@@ -80,9 +83,9 @@ void AMissile::FindPlayer()
 			{
 				if (FoundPlayer->ActorHasTag(PlayerTagName))
 				{
-					if (PlayerInWorld != FoundPlayer)
+					if (PlayerCharacter != FoundPlayer)
 					{
-						PlayerInWorld = FoundPlayer;
+						PlayerCharacter = FoundPlayer;
 					}
 				}
 			}
@@ -95,11 +98,11 @@ void AMissile::UpdateTarget()
 {
 	if (!hasTargetPosition)
 	{
-		if (PlayerInWorld != NULL)
+		if (target == NULL)
 		{
-			if (PlayerInWorld->IsValidLowLevel())
+			if (PlayerCharacter->IsValidLowLevel())
 			{
-				target = PlayerInWorld;
+				target = PlayerCharacter;
 				hasTargetPosition = true;
 				hasNoTarget = false;
 				

--- a/Source/MissileDemo/Missile.cpp
+++ b/Source/MissileDemo/Missile.cpp
@@ -19,8 +19,6 @@ AMissile::AMissile(const FObjectInitializer& ObjectInitializer) : Super(ObjectIn
 
 	// Construct Static Mesh Component
 	MissileMesh = ObjectInitializer.CreateDefaultSubobject<UStaticMeshComponent>(this, TEXT("MissileMesh"));
-	//const ConstructorHelpers::FObjectFinder<UStaticMesh> MeshObj(TEXT("/Game/Missile/Missile_01_Model"));
-	//MissileMesh->SetStaticMesh(MeshObj.Object);
 	MissileMesh->SetupAttachment(RootComponent);
 
 	// Construct Projectile Movement Component
@@ -204,29 +202,29 @@ void AMissile::Tick(float DeltaTime)
 
 #pragma region Overlap Events
 // If our missile overlaps the player or the ground, it will be destroyed
-void AMissile::OnOverlapBegin(UPrimitiveComponent* overlappedComp, AActor* otherActor, UPrimitiveComponent* otherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult &hitResult)
-{
-	class AMyCharacter* PlayerCharacter = Cast<AMyCharacter>(otherActor);
-	class AStaticMeshActor* GroundActor = Cast<AStaticMeshActor>(otherActor);
-
-	if (PlayerCharacter != nullptr)
-	{
-		PlayExplosion(ExplosionSystem);
-		PlayExplosionSound(ExplosionSound);
-
-		if (this->IsValidLowLevel())
-			Destroy();
-	}
-
-	if (GroundActor != nullptr)
-	{
-		PlayExplosion(ExplosionSystem);
-		PlayExplosionSound(ExplosionSound);
-
-		if (this->IsValidLowLevel())
-			Destroy();
-	}
-}
+//void AMissile::OnOverlapBegin(UPrimitiveComponent* overlappedComp, AActor* otherActor, UPrimitiveComponent* otherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult &hitResult)
+//{
+//	class AMyCharacter* PlayerCharacter = Cast<AMyCharacter>(otherActor);
+//	class AStaticMeshActor* GroundActor = Cast<AStaticMeshActor>(otherActor);
+//
+//	if (PlayerCharacter != nullptr)
+//	{
+//		PlayExplosion(ExplosionSystem);
+//		PlayExplosionSound(ExplosionSound);
+//
+//		if (this->IsValidLowLevel())
+//			Destroy();
+//	}
+//
+//	if (GroundActor != nullptr)
+//	{
+//		PlayExplosion(ExplosionSystem);
+//		PlayExplosionSound(ExplosionSound);
+//
+//		if (this->IsValidLowLevel())
+//			Destroy();
+//	}
+//}
 #pragma endregion
 
 #pragma region End of Play Logic

--- a/Source/MissileDemo/Missile.h
+++ b/Source/MissileDemo/Missile.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Components/StaticMeshComponent.h"
+#include "GameFramework/ProjectileMovementComponent.h"
 #include "GameFramework/Actor.h"
 #include "Missile.generated.h"
 
@@ -28,8 +30,8 @@ private:
 	void Explode();
 
 	// Event to Detect When an Actor Overlaps the Missile Class
-	UFUNCTION()
-	void OnOverlapBegin(UPrimitiveComponent* overlappedComp, AActor* otherActor, UPrimitiveComponent* otherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult &hitResult);
+	//UFUNCTION()
+	//void OnOverlapBegin(UPrimitiveComponent* overlappedComp, AActor* otherActor, UPrimitiveComponent* otherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult &hitResult);
 		
 public:	
 
@@ -43,7 +45,7 @@ protected:
 
 	// Reference To Our Player in World
 	UPROPERTY()
-	class AMyCharacter* PlayerInWorld;
+	class AActor* PlayerCharacter;
 
 public:	
 


### PR DESCRIPTION
Note: OnOverlapBegin still giving problems, commented out until is fixed.

- Removed "MyCharacter" and Missile Mesh dependencies so it can also be used on other projects.
- Fixed a bug where the target was never set.